### PR TITLE
Add basic Three.js example page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Three.js Example
+
+This repository contains a very small example that displays a spinning cube using [Three.js](https://threejs.org/).
+
+## Running the example
+
+1. Install dependencies:
+   ```sh
+   npm install
+   ```
+2. Start a local server:
+   ```sh
+   npm start
+   ```
+3. Open the provided URL (typically http://localhost:8080) in your browser to see the cube.
+
+The server is provided by [`http-server`](https://www.npmjs.com/package/http-server) and is configured as a development dependency.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Three.js Example</title>
+  <style>
+    body { margin: 0; }
+    canvas { display: block; }
+  </style>
+</head>
+<body>
+  <script src="https://unpkg.com/three@0.160.1/build/three.min.js"></script>
+  <script>
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+
+    const renderer = new THREE.WebGLRenderer();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(renderer.domElement);
+
+    const geometry = new THREE.BoxGeometry(1, 1, 1);
+    const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+    const cube = new THREE.Mesh(geometry, material);
+    scene.add(cube);
+
+    camera.position.z = 5;
+
+    function animate() {
+      requestAnimationFrame(animate);
+      cube.rotation.x += 0.01;
+      cube.rotation.y += 0.01;
+      renderer.render(scene, camera);
+    }
+
+    animate();
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "tree3js",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "http-server"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "http-server": "^14.1.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add an example `index.html` that includes Three.js via CDN and renders a spinning cube
- add `http-server` as a dev dependency with a start script
- add a README with instructions to run the example

## Testing
- `npx http-server --version`
- `node -e "console.log('test run')"`


------
https://chatgpt.com/codex/tasks/task_e_684827dbf77083218fdfb0b9b78f5791